### PR TITLE
Added NVMe log format temperature parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ output:
           -c TEMP, --critical-threshold=TEMP
                                 set temperature critical threshold to given
                                 temperature (defaults to 60)
+          -p, --performance-data
+                                enable the Nagios performance output format
 
 ## Monitor configuration ##
 Read the Nagios documentation and create a command definition and service.like

--- a/check_smartmon.py
+++ b/check_smartmon.py
@@ -171,7 +171,7 @@ def call_smartmontools(path, device):
             # bit 3 is set - smart status returned DISK FAILING
             # we still want to see what the output says
             result = error.output
-            message += "CRITICAL: SMART statis is DISK FAILING "
+            message += "CRITICAL: SMART status is DISK FAILING "
             return_code -= 2**3
             code_to_return = 2
         if return_code % 2**5 > 0:

--- a/check_smartmon.py
+++ b/check_smartmon.py
@@ -226,6 +226,7 @@ def parse_output(output, warning_temp, critical_temp):
     error_count = 0
 
     lines = output.split("\n")
+    
     for line in lines:
         # extract status line
         if "overall-health self-assessment test result" in line:
@@ -239,60 +240,66 @@ def parse_output(output, warning_temp, critical_temp):
             parts = status_line.rstrip().split()
             health_status = parts[-1:][0]
             vprint(3, "Health status: %s" % health_status)
-
-        parts = line.split()
-        if len(parts) > 0:
-            # self test spans can also start with 5, so we
-            # need a tighter check here than elsewhere
-            if parts[0] == "5" and \
-                    parts[1] == "Reallocated_Sector_Ct" and \
-                    reallocated_sector_ct == 0:
-                # extract reallocated_sector_ct
-                # 5 is the reallocated_sector_ct id
-                reallocated_sector_ct = int(parts[9])
-                vprint(3, "Reallocated_Sector_Ct: %d" % reallocated_sector_ct)
-            elif parts[0] == "190" and temperature == 0:
-                # extract temperature
-                # 190 can be temperature value id too
-                temperature = int(parts[9])
-                vprint(3, "Temperature: %d" % temperature)    
-            elif parts[0] == "194" and temperature == 0:
-                # extract temperature
-                # 194 is the temperature value id
-                temperature = int(parts[9])
-                vprint(3, "Temperature: %d" % temperature)
-            elif parts[0] == "196" and reallocated_event_count == 0:
-                # extract reallocated_event_count
-                # 196 is the reallocated_event_count id
-                reallocated_event_count = int(parts[9])
-                vprint(
-                    3,
-                    "Reallocated_Event_Count: %d" % reallocated_event_count)
-            elif parts[0] == "197" and current_pending_sector == 0:
-                # extract current_pending_sector
-                # 197 is the current_pending_sector id
-                current_pending_sector = int(parts[9])
-                vprint(
-                    3,
-                    "Current_Pending_Sector: %d" % current_pending_sector)
-            elif parts[0] == "198" and offline_uncorrectable == 0:
-                # extract offline_uncorrectable
-                # 198 is the offline_uncorrectable id
-                offline_uncorrectable = int(parts[9])
-                vprint(
-                    3,
-                    "Offline_Uncorrectable: %d" % offline_uncorrectable)
-            elif "ATA Error Count" in line:
-                error_count = int(parts[3])
-                vprint(
-                    3,
-                    "ATA error count: %d" % error_count)
-            elif "No Errors Logged" in line:
-                error_count = 0
-                vprint(
-                    3,
-                    "ATA error count: 0")
-
+        
+        if 'NVMe Log' in output:
+            vprint(3, "Device is a NVMe, parsing specific output format")
+            if "Temperature:" in line:
+                parts = line.split()
+                temperature = int(parts[1])
+        else:
+            parts = line.split()
+            if len(parts) > 0:
+                # self test spans can also start with 5, so we
+                # need a tighter check here than elsewhere
+                if parts[0] == "5" and \
+                        parts[1] == "Reallocated_Sector_Ct" and \
+                        reallocated_sector_ct == 0:
+                    # extract reallocated_sector_ct
+                    # 5 is the reallocated_sector_ct id
+                    reallocated_sector_ct = int(parts[9])
+                    vprint(3, "Reallocated_Sector_Ct: %d" % reallocated_sector_ct)
+                elif parts[0] == "190" and temperature == 0:
+                    # extract temperature
+                    # 190 can be temperature value id too
+                    temperature = int(parts[9])
+                    vprint(3, "Temperature: %d" % temperature)    
+                elif parts[0] == "194" and temperature == 0:
+                    # extract temperature
+                    # 194 is the temperature value id
+                    temperature = int(parts[9])
+                    vprint(3, "Temperature: %d" % temperature)
+                elif parts[0] == "196" and reallocated_event_count == 0:
+                    # extract reallocated_event_count
+                    # 196 is the reallocated_event_count id
+                    reallocated_event_count = int(parts[9])
+                    vprint(
+                        3,
+                        "Reallocated_Event_Count: %d" % reallocated_event_count)
+                elif parts[0] == "197" and current_pending_sector == 0:
+                    # extract current_pending_sector
+                    # 197 is the current_pending_sector id
+                    current_pending_sector = int(parts[9])
+                    vprint(
+                        3,
+                        "Current_Pending_Sector: %d" % current_pending_sector)
+                elif parts[0] == "198" and offline_uncorrectable == 0:
+                    # extract offline_uncorrectable
+                    # 198 is the offline_uncorrectable id
+                    offline_uncorrectable = int(parts[9])
+                    vprint(
+                        3,
+                        "Offline_Uncorrectable: %d" % offline_uncorrectable)
+                elif "ATA Error Count" in line:
+                    error_count = int(parts[3])
+                    vprint(
+                        3,
+                        "ATA error count: %d" % error_count)
+                elif "No Errors Logged" in line:
+                    error_count = 0
+                    vprint(
+                        3,
+                        "ATA error count: 0")
+        
     # now create the return information for this device
     return_status = 0
     device_status = ""


### PR DESCRIPTION
Hi, I am using your plugin with a NVMe unit and the current version is not able to parse temperature from SMART log in NVMe format. It seems that information do not have any ID associated (e.g. Temperature should be 190 or 194).

I modified the script to read the "Temperature" field when the output is in NVMe Log format.

## Example of NVMe Log output

    # smartctl -a /dev/nvme0
    smartctl 6.6 2016-05-31 r4324 [x86_64-linux-4.9.0-4-amd64] (local build)
    Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
    
    === START OF INFORMATION SECTION ===
    Model Number:                       Samsung SSD 960 EVO 250GB
    Serial Number:                      xxxxxxxxxxxxxx
    Firmware Version:                   2B7QCXE7
    PCI Vendor/Subsystem ID:            0x144d
    IEEE OUI Identifier:                0x002538
    Total NVM Capacity:                 250,059,350,016 [250 GB]
    Unallocated NVM Capacity:           0
    Controller ID:                      2
    Number of Namespaces:               1
    Namespace 1 Size/Capacity:          250,059,350,016 [250 GB]
    Namespace 1 Utilization:            13,835,751,424 [13.8 GB]
    Namespace 1 Formatted LBA Size:     512
    Local Time is:                      Fri Apr  6 11:45:41 2018 CEST
    Firmware Updates (0x16):            3 Slots, no Reset required
    Optional Admin Commands (0x0007):   Security Format Frmw_DL
    Optional NVM Commands (0x001f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat
    Maximum Data Transfer Size:         512 Pages
    Warning  Comp. Temp. Threshold:     77 Celsius
    Critical Comp. Temp. Threshold:     79 Celsius
    
    Supported Power States
    St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
     0 +     6.04W       -        -    0  0  0  0        0       0
     1 +     5.09W       -        -    1  1  1  1        0       0
     2 +     4.08W       -        -    2  2  2  2        0       0
     3 -   0.0400W       -        -    3  3  3  3      210    1500
     4 -   0.0050W       -        -    4  4  4  4     2200    6000
    
    Supported LBA Sizes (NSID 0x1)
    Id Fmt  Data  Metadt  Rel_Perf
     0 +     512       0         0
    
    === START OF SMART DATA SECTION ===
    SMART overall-health self-assessment test result: PASSED
    
    SMART/Health Information (NVMe Log 0x02, NSID 0xffffffff)
    Critical Warning:                   0x00
    Temperature:                        31 Celsius
    Available Spare:                    100%
    Available Spare Threshold:          10%
    Percentage Used:                    0%
    Data Units Read:                    14,150 [7.24 GB]
    Data Units Written:                 50,165 [25.6 GB]
    Host Read Commands:                 270,117
    Host Write Commands:                304,134
    Controller Busy Time:               2
    Power Cycles:                       24
    Power On Hours:                     657
    Unsafe Shutdowns:                   2
    Media and Data Integrity Errors:    0
    Error Information Log Entries:      0
    Warning  Comp. Temperature Time:    0
    Critical Comp. Temperature Time:    0
    Temperature Sensor 1:               31 Celsius
    Temperature Sensor 2:               44 Celsius
    
    Error Information (NVMe Log 0x01, max 64 entries)
    No Errors Logged
    